### PR TITLE
remove inf for calc_panel_params

### DIFF
--- a/R/stats.R
+++ b/R/stats.R
@@ -89,6 +89,7 @@ StatDensityRidges <- ggproto("StatDensityRidges", Stat,
   calc_panel_params = function(data, params) {
     if (is.null(params$bandwidth)) {
       xdata <- na.omit(data.frame(x=data$x, group=data$group))
+      xdata <- xdata[is.finite(xdata$x), ]
       xs <- split(xdata$x, xdata$group)
       xs_mask <- vapply(xs, length, numeric(1)) > 1
       bws <- vapply(xs[xs_mask], bw.nrd0, numeric(1))
@@ -99,11 +100,11 @@ StatDensityRidges <- ggproto("StatDensityRidges", Stat,
     }
 
     if (is.null(params$from)) {
-      params$from <- min(data$x, na.rm=TRUE) - 3 * params$bandwidth
+      params$from <- min(data$x[is.finite(data$x)], na.rm=TRUE) - 3 * params$bandwidth
     }
 
     if (is.null(params$to)) {
-      params$to <- max(data$x, na.rm=TRUE) + 3 * params$bandwidth
+      params$to <- max(data$x[is.finite(data$x)], na.rm=TRUE) + 3 * params$bandwidth
     }
 
     data.frame(


### PR DESCRIPTION
The suggested changes fix problems I was having when handling infinite values with stat_density_ridges(). Here's a MWE:
```R
library(ggplot2)
library(ggridges)
set.seed(1234)

# works
dat2 <- data.frame(x = c(rnorm(20)),
                   y = c(rep("a", 10), rep("b", 10)))

ggplot(dat2, aes(x = x, y = y)) + geom_density_ridges()

# doesn't work
dat <- data.frame(x = c(rnorm(19), Inf),
                  y = c(rep("a", 10), rep("b", 10)))

ggplot(dat, aes(x = x, y = y)) + geom_density_ridges()

# Error in if (!(lo <- min(hi, IQR(x)/1.34))) (lo <- hi) || (lo <- abs(x[1L])) ||  : 
# missing value where TRUE/FALSE needed
```
I think that the changes should minimally impact other functions. Also, this is my first pull request so let me know if I did anything wrong.