### PR TITLE
fix #48

### DIFF
--- a/R/stats.R
+++ b/R/stats.R
@@ -198,7 +198,7 @@ StatDensityRidges <- ggproto("StatDensityRidges", Stat,
     }
 
     # calculate quantiles, needed for both quantile lines and ecdf
-    if (length(quantiles)==1) {
+    if ((length(quantiles)==1) && (all(quantiles >= 1))) {
       if (quantiles > 1) {
         probs <- seq(0, 1, length.out = quantiles + 1)[2:quantiles]
       }


### PR DESCRIPTION
Allow user to pass a scalar `quantile` in, without it being interpreted as the number of divisions.