### PR TITLE
Fix typo in stat_binline example

### DIFF
--- a/R/stats.R
+++ b/R/stats.R
@@ -330,7 +330,7 @@ StatDensityRidges <- ggproto("StatDensityRidges", Stat,
 #'    scale_y_reverse(expand = c(0, 0)) +
 #'    scale_fill_viridis_d(begin = 0.3, option = "B") +
 #'    coord_cartesian(clip = "off") +
-#'    labs(title = "Movie lengths 1990 - 2005")
+#'    labs(title = "Movie lengths 1990 - 2005") +
 #'    theme_ridges() +
 #'    theme(legend.position = "none")
 #'


### PR DESCRIPTION
One of the examples had a missing `+` that made the [output hard to read](https://wilkelab.org/ggridges/reference/stat_binline.html#:~:text=%23%3E-,List,-of%2093%0A%23%3E%20%20%24%20line). (If this is harder to merge than just correcting directly, feel free to ignore/reject ... just trying to be helpful ...)