### PR TITLE
Fix warnings for size and expand_scale from ggplot2 0.3.3/0.3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggridges
 Type: Package
 Title: Ridgeline Plots in 'ggplot2'
-Version: 0.5.4
+Version: 0.5.5
 Authors@R: 
     person(
       given = "Claus O.",
@@ -16,7 +16,7 @@ BugReports: https://github.com/wilkelab/ggridges/issues
 Depends:
     R (>= 3.2)
 Imports:
-    ggplot2 (>= 3.0.0),
+    ggplot2 (>= 3.4.0),
     grid (>= 3.0.0),
     scales (>= 0.4.1),
     withr (>= 2.1.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+ggridges 0.5.5
+----------------------------------------------------------------
+- Replace `ggplot2::expand_scale()` with `ggplot2::expansion()` in vignettes to avoid deprecation warnings in [ggplot2 0.3.3](https://ggplot2.tidyverse.org/news/index.html#minor-improvements-and-bug-fixes-3-3-0)
+- Replace `size` argument in line functions (geomsv.R) with `linewidth` to avoid deprecation warnings in [ggplot2 0.3.4](https://ggplot2.tidyverse.org/news/index.html#breaking-changes-3-4-0)
+
 ggridges 0.5.4
 ----------------------------------------------------------------
 - Remove broken link in docs.

--- a/R/geomsv.R
+++ b/R/geomsv.R
@@ -32,7 +32,7 @@
 #'   a warning. If `TRUE`, missing values are silently removed.
 #' @param ... other arguments passed on to [`layer()`]. These are
 #'   often aesthetics, used to set an aesthetic to a fixed value, like
-#'   `color = "red"` or `size = 3`. They may also be parameters
+#'   `color = "red"` or `linewidth = 3`. They may also be parameters
 #'   to the paired geom/stat.
 #'
 #' @section Aesthetics:
@@ -57,7 +57,7 @@
 #'   color as RGBA value, e.g. #FF0000A0 for partially transparent red.
 #' * `group` Grouping, to draw multiple ridgelines from one dataset
 #' * `linetype` Linetype of the ridgeline
-#' * `size` Line thickness
+#' * `linewidth` Line thickness
 #'
 #' @examples
 #' library(ggplot2)
@@ -95,7 +95,7 @@ geom_vridgeline <- function(mapping = NULL, data = NULL, stat = "identity",
 #' @importFrom ggplot2 ggproto Geom draw_key_polygon
 #' @export
 GeomVRidgeline <- ggproto("GeomVRidgeline", Geom,
-  default_aes = aes(color = "black", fill = "grey80", x = 0, size = 0.5, linetype = 1,
+  default_aes = aes(color = "black", fill = "grey80", x = 0, linewidth = 0.5, linetype = 1,
         min_width = 0, scale = 1, alpha = NA),
 
   required_aes = c("x", "y", "width"),
@@ -154,7 +154,7 @@ GeomVRidgeline <- ggproto("GeomVRidgeline", Geom,
     data$xmax[data$width < data$min_width] <- NA
 
     # Check that aesthetics are constant
-    aes <- unique(data[c("colour", "fill", "size", "linetype", "alpha")])
+    aes <- unique(data[c("colour", "fill", "linewidth", "linetype", "alpha")])
     if (nrow(aes) > 1) {
       stop("Aesthetics can not vary along a ridgeline")
     }
@@ -198,7 +198,7 @@ GeomVRidgeline <- ggproto("GeomVRidgeline", Geom,
                  default.units = "native",
                  gp = grid::gpar(
                    col = aes$colour,
-                   lwd = aes$size * .pt,
+                   lwd = aes$linewidth * .pt,
                    lty = aes$linetype)
                ))
 

--- a/man/geom_density_line.Rd
+++ b/man/geom_density_line.Rd
@@ -18,10 +18,10 @@ geom_density_line(
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -39,10 +39,14 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, as a string.}
+layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
+stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
+\code{"stat_count"})}
 
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
+\item{position}{Position adjustment, either as a string naming the adjustment
+(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
+position adjustment function. Use the latter if you need to change the
+settings of the adjustment.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like

--- a/man/geom_vridgeline.Rd
+++ b/man/geom_vridgeline.Rd
@@ -54,7 +54,7 @@ rather than combining with them.}
 
 \item{...}{other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{color = "red"} or \code{linewidth = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
@@ -84,7 +84,7 @@ scaling is applied via the \code{scale} aesthetic. Default is 0, so negative val
 color as RGBA value, e.g. #FF0000A0 for partially transparent red.
 \item \code{group} Grouping, to draw multiple ridgelines from one dataset
 \item \code{linetype} Linetype of the ridgeline
-\item \code{size} Line thickness
+\item \code{linewidth} Line thickness
 }
 }
 

--- a/man/stat_binline.Rd
+++ b/man/stat_binline.Rd
@@ -26,10 +26,10 @@ stat_binline(
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -48,8 +48,10 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{The geom to use for drawing.}
 
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
+\item{position}{Position adjustment, either as a string naming the adjustment
+(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
+position adjustment function. Use the latter if you need to change the
+settings of the adjustment.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like

--- a/vignettes/gallery.Rmd
+++ b/vignettes/gallery.Rmd
@@ -76,7 +76,7 @@ Modified from a [blog post](https://austinwehrwein.com/data-visualization/it-bri
 ggplot(lincoln_weather, aes(x = `Mean Temperature [F]`, y = Month, fill = stat(x))) +
   geom_density_ridges_gradient(scale = 3, rel_min_height = 0.01, gradient_lwd = 1.) +
   scale_x_continuous(expand = c(0, 0)) +
-  scale_y_discrete(expand = expand_scale(mult = c(0.01, 0.25))) +
+  scale_y_discrete(expand = expansion(mult = c(0.01, 0.25))) +
   scale_fill_viridis_c(name = "Temp. [F]", option = "C") +
   labs(
     title = 'Temperatures in Lincoln NE',
@@ -112,7 +112,7 @@ ggplot(pois_data, aes(x = value, y = group, group = group)) +
     expand = c(0, 0), name = "random value"
   ) +
   scale_y_discrete(
-    expand = expand_scale(add = c(0, 1.)), name = "Poisson mean",
+    expand = expansion(add = c(0, 1.)), name = "Poisson mean",
     labels = c("5.0", "4.0", "3.0", "2.0", "1.0")
   ) +
   scale_fill_cyclical(values = c("#0000B0", "#7070D0")) +


### PR DESCRIPTION
- Replace `ggplot2::expand_scale()` with `ggplot2::expansion()` in vignettes to avoid deprecation warnings in [ggplot2 0.3.3](https://ggplot2.tidyverse.org/news/index.html#minor-improvements-and-bug-fixes-3-3-0)
- Replace `size` argument in line functions (geomsv.R) with `linewidth` to avoid deprecation warnings in [ggplot2 0.3.4](https://ggplot2.tidyverse.org/news/index.html#breaking-changes-3-4-0)

Closes #78 

No warnings/notes/errors on local testing
