### PR TITLE
Test for absence/presence of guide differently

### DIFF
--- a/tests/testthat/test_scale_cyclical.R
+++ b/tests/testthat/test_scale_cyclical.R
@@ -12,7 +12,11 @@ test_that("basic tests", {
   expect_equal(d$colour, rep(c("#F00000", "#0000F0"), 13))
 
   # make sure there is no legend being generated
-  expect_equal("guide-box" %in% ggplotGrob(p)$layout$name, FALSE)
+  if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
+    expect_null(get_guide_data(p, "colour"))
+  } else {
+    expect_equal("guide-box" %in% ggplotGrob(p)$layout$name, FALSE)
+  }
 
   # once again, different aesthetic, different cyclical pattern, now with legend
   p <- ggplot(df, aes(x, y, label=letters, color=factor(x))) + geom_text() +
@@ -23,7 +27,11 @@ test_that("basic tests", {
   expect_equal(d$colour[order(d$x)], rep(c("#F00000", "#0000F0", "#F0F000"), 9)[1:26])
 
   # make sure there is a legend
-  expect_equal("guide-box" %in% ggplotGrob(p)$layout$name, TRUE)
+  if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
+    expect_s3_class(get_guide_data(p, "colour"), "data.frame")
+  } else {
+    expect_equal("guide-box" %in% ggplotGrob(p)$layout$name, TRUE)
+  }
 
   # test that breaks must match labels
   expect_error(

--- a/tests/testthat/test_scale_cyclical.R
+++ b/tests/testthat/test_scale_cyclical.R
@@ -12,6 +12,7 @@ test_that("basic tests", {
   expect_equal(d$colour, rep(c("#F00000", "#0000F0"), 13))
 
   # make sure there is no legend being generated
+  # in ggplot2 >= 3.5.0 legend structure in gtable changed
   if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
     expect_null(get_guide_data(p, "colour"))
   } else {
@@ -27,6 +28,7 @@ test_that("basic tests", {
   expect_equal(d$colour[order(d$x)], rep(c("#F00000", "#0000F0", "#F0F000"), 9)[1:26])
 
   # make sure there is a legend
+  # in ggplot2 >= 3.5.0 legend structure in gtable changed
   if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
     expect_s3_class(get_guide_data(p, "colour"), "data.frame")
   } else {


### PR DESCRIPTION
Hi Claus,

It is me again, running down reverse dependency checks. I'm posting this because the prospective ggplot2 3.5.0 would break a test in ggridges.

The change is that a plot now always has guide boxes (though they are zero grobs if empty). Hence, testing for presence/absence of a guide by checking the gtable for the 'guide-box' name no longer works. This PR uses the new `get_guide_data()` to test for a legend's presence or absence.

For completion; to test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. I hope that this PR might help ggridges get out a fix if necessary.