### PR TITLE
feat: Support `grid::pattern()` / gradient fills

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ BugReports: https://github.com/wilkelab/ggridges/issues
 Depends:
     R (>= 3.2)
 Imports:
-    ggplot2 (>= 3.4.0),
+    ggplot2 (>= 3.5.0),
     grid (>= 3.0.0),
     scales (>= 0.4.1),
     withr (>= 2.1.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@ ggridges 0.5.6.9000
 ----------------------------------------------------------------
 - Add support for weighted density estimates in `stat_density_ridges()` by 
   allowing the use of the `weight` aesthetic (@joranE, #90)
+- Add support for `grid::pattern()`, `grid::linearGradient()`, and `grid::radialGradient()` values for `fill` and `point_fill` aesthetics
+  by using [`ggplot2::fill_alpha()`](https://ggplot2.tidyverse.org/reference/fill_alpha.html) (@trevorld, #94)
 
 ggridges 0.5.6
 ----------------------------------------------------------------

--- a/R/geoms-gradient.R
+++ b/R/geoms-gradient.R
@@ -164,7 +164,7 @@ GeomRidgelineGradient <- ggproto("GeomRidgelineGradient", Geom,
             data$point_colour %||% data$point_color %||% data$colour,
             data$point_alpha %||% data$alpha
           ),
-          fill = alpha(
+          fill = ggplot2::fill_alpha(
             data$point_fill %||% data$fill,
             data$point_alpha %||% data$alpha
           ),
@@ -303,7 +303,7 @@ GeomRidgelineGradient <- ggproto("GeomRidgelineGradient", Geom,
                  data$point_colour %||% data$point_color %||% data$colour,
                  data$point_alpha %||% data$alpha
                ),
-               fill = alpha(
+               fill = ggplot2::fill_alpha(
                  data$point_fill %||% data$fill,
                  data$point_alpha %||% data$alpha
                ),

--- a/R/geoms.R
+++ b/R/geoms.R
@@ -157,7 +157,7 @@ GeomRidgeline <- ggproto("GeomRidgeline", Geom,
       height = grid::unit(1, "npc") - grid::unit(lwd, "mm"),
       gp = grid::gpar(
         col = data$colour,
-        fill = alpha(data$fill, data$alpha),
+        fill = ggplot2::fill_alpha(data$fill, data$alpha),
         lty = data$linetype,
         lwd = lwd * .pt,
         linejoin = "mitre"
@@ -191,7 +191,7 @@ GeomRidgeline <- ggproto("GeomRidgeline", Geom,
             data$point_colour %||% data$point_color %||% data$colour,
             data$point_alpha %||% data$alpha
           ),
-          fill = alpha(
+          fill = ggplot2::fill_alpha(
             data$point_fill %||% data$fill,
             data$point_alpha %||% data$alpha
           ),
@@ -304,7 +304,7 @@ GeomRidgeline <- ggproto("GeomRidgeline", Geom,
                  data$point_colour %||% data$point_color %||% data$colour,
                  data$point_alpha %||% data$alpha
                ),
-               fill = alpha(
+               fill = ggplot2::fill_alpha(
                  data$point_fill %||% data$fill,
                  data$point_alpha %||% data$alpha
                ),
@@ -355,7 +355,7 @@ GeomRidgeline <- ggproto("GeomRidgeline", Geom,
              munched_poly$x, munched_poly$y, id = munched_poly$id,
              default.units = "native",
              gp = grid::gpar(
-               fill = ggplot2::alpha(aes$fill, aes$alpha),
+               fill = ggplot2::fill_alpha(aes$fill, aes$alpha),
                lty = 0)
              )
            )
@@ -591,7 +591,7 @@ GeomDensityRidges2 <- ggproto("GeomDensityRidges2", GeomDensityRidges,
              munched_poly$x, munched_poly$y, id = munched_poly$id,
              default.units = "native",
              gp = grid::gpar(
-             fill = ggplot2::alpha(aes$fill, aes$alpha),
+             fill = ggplot2::fill_alpha(aes$fill, aes$alpha),
              col = aes$colour,
              lwd = aes$linewidth * .pt,
              lty = aes$linetype)

--- a/R/geomsv.R
+++ b/R/geomsv.R
@@ -207,7 +207,7 @@ GeomVRidgeline <- ggproto("GeomVRidgeline", Geom,
                  munched_poly$x, munched_poly$y, id = munched_poly$id,
                  default.units = "native",
                  gp = grid::gpar(
-                   fill = ggplot2::alpha(aes$fill, aes$alpha),
+                   fill = ggplot2::fill_alpha(aes$fill, aes$alpha),
                    lty = 0)
                ))
     grid::grobTree(ag, lg)


### PR DESCRIPTION
* Bumps required {ggplot2} to v3.5.0 when `fill_alpha()` was introduced.
* Replace each `fill = alpha(fill, alpha)` with `fill = fill_alpha(fill, alpha)`.

closes #94